### PR TITLE
correct path to avoid errors during bundling

### DIFF
--- a/versatile_rjs.gemspec
+++ b/versatile_rjs.gemspec
@@ -25,9 +25,6 @@ Gem::Specification.new do |s|
     "README.rdoc",
     "Rakefile",
     "VERSION",
-    "features/step_definitions/versatile_rjs_steps.rb",
-    "features/support/env.rb",
-    "features/versatile_rjs.feature",
     "init.rb",
     "lib/versatile_rjs.rb",
     "lib/versatile_rjs/container.rb",
@@ -98,4 +95,3 @@ Gem::Specification.new do |s|
     s.add_dependency(%q<jruby-openssl>, [">= 0"])
   end
 end
-


### PR DESCRIPTION
"versatile_rjs at /home/swelther/.rvm/gems/ruby-2.2.0@blah/bundler/gems/versatile_rjs-a47a499c460a did not have a valid gemspec.
This prevents bundler from installing bins or native extensions, but that may not affect its functionality.
The validation message from Rubygems was:
  ["features/versatile_rjs.feature"] are not files"
